### PR TITLE
Feat/buzzer+adc+uart: buzzer 프로젝트 구현

### DIFF
--- a/buzzer+adc+uart/ADC.c
+++ b/buzzer+adc+uart/ADC.c
@@ -1,0 +1,48 @@
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include "define.h"
+#include "ADC.h"
+
+uint8_t adc_low = 0, adc_high = 0;
+
+void ADC_init()
+{
+	ADMUX = 0b00000000;
+	/*
+	ADMUX의 offset : 0x07, 0b00000111 -> 기본 64분주
+		ADMUX &= ~(1<<REFS1) | ~(1<<REFS0);										// 7~6BIT: REFS1~0 = 00 ) 기준 전압을 AVCC(5V)로 쓴다. (JKIT-128-1은 AREF만 사용 가능)
+		ADMUX &= ~(1<<ADLAR);													// 5BIT: ADLAR = 0 ) 오른쪽 정렬
+		ADMUX &= ~(1<<MUX4)| ~(1<<MUX3) | ~(1<<MUX2) | ~(1<<MUX1) | ~(1<<MUX0);	// 4~0BIT: MUX4~0 = 00000 ) ADC0 입력 채널 사용
+	*/
+
+	ADCSRA = 0b10000111;
+	/*
+	ADCSRA의 offset : 0x06, 0b00000110 -> 기본 64분주
+		ADCSRA |= (1<<ADEN);	// 7BIT: ADEN = 1 ) ADC 사용함
+		ADCSRA &= ~(1<<ADSC);   // 6BIT: ADSC = 0 ) ADC 아직 시작 안 함
+		ADCSRA &= ~(1<<ADFR);	// 5BIT: ADFR = 0 ) single conversion mode
+		ADCSRA &= ~(1<<ADIF);	// 4BIT: ADIF = 0 ) 아직 ADC를 시작하지 않아서 0으로 정해둠
+		ADCRA &= ~(1<<ADIE);	// 3BIT: ADIE = 0 ) ADC 인터럽트 안 씀
+		ADCSRA |= (1<<ADPS2) | (1<<ADPS1) | (1<<ADPS0);	// 2~0BIT: ADPS2~0 = 1 1 1 ) 128 분주
+	*/
+}
+
+uint16_t ADC_read()
+{
+	adc_low = 0;
+	adc_high = 0;
+
+	unsigned short value = 0;
+
+	ADCSRA |= (1 << ADSC); // ADC 읽기 시작
+	while (!(ADCSRA & (1 << ADIF)))
+		; // ADSC가 0이 될 때까지 (ADC 끝날 때까지) 대기
+
+	adc_low = ADCL;
+	adc_high = ADCH;
+
+	value = (adc_high << 8) | adc_low;
+
+	// return adc_high;
+	return value;
+}

--- a/buzzer+adc+uart/ADC.h
+++ b/buzzer+adc+uart/ADC.h
@@ -1,0 +1,10 @@
+#ifndef ADC_H_
+#define ADC_H_
+
+uint8_t adc_low;
+uint8_t adc_high;
+
+void ADC_init();
+uint16_t ADC_read();
+
+#endif

--- a/buzzer+adc+uart/External_Interrupt.c
+++ b/buzzer+adc+uart/External_Interrupt.c
@@ -1,0 +1,46 @@
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include "define.h"
+#include "timer1.h"
+#include "External_Interrupt.h"
+
+volatile int duty_mode = 1;
+
+void ExternalInterrupt_init()
+{
+	EICRB |= (1 << ISC51);
+	EIMSK |= (1 << INT5);
+}
+
+ISR(INT5_vect)
+{ // sw2
+	switch (duty_mode)
+	{ // timer1 pwm 듀티 조절
+	case 1:
+		set_pwm_duty(80);
+		duty_mode = 2;
+		PORTA = 0x02;
+		break;
+	case 2:
+		set_pwm_duty(60);
+		duty_mode = 3;
+		PORTA = 0x04;
+		break;
+	case 3:
+		set_pwm_duty(40);
+		duty_mode = 4;
+		PORTA = 0x08;
+		break;
+	case 4:
+		set_pwm_duty(20);
+		duty_mode = 5;
+		PORTA = 0x10;
+		break;
+	case 5:
+		set_pwm_duty(100);
+		duty_mode = 1;
+		PORTA = 0x01;
+		break;
+	}
+}

--- a/buzzer+adc+uart/External_Interrupt.h
+++ b/buzzer+adc+uart/External_Interrupt.h
@@ -1,0 +1,6 @@
+#ifndef EXTERNAL_INTERRUPT_H_
+#define EXTERNAL_INTERRUPT_H_
+
+void ExternalInterrupt_init();
+
+#endif /* EXTERNAL_INTERRUPT_H_ */

--- a/buzzer+adc+uart/Readme.md
+++ b/buzzer+adc+uart/Readme.md
@@ -1,0 +1,19 @@
+# buzzer 프로젝트
+## 사용핀
+- **PA0-7**: 동작 여부 확인을 위해 사용
+- **PF0** : ADC0 채널 사용
+- **PE0-1** : UART 통신을 위해 사용
+- **PB4** : TIMER 0: 1ms task용
+- **PB5** : TIMER1A: TOP=OCR1A FAST PWM 모드 사용
+- **PB6** : TIEMR1B: 외부 부저 연결 + 듀티 조절을 OCR1B로 하기 위해 사용
+
+## 기능
+- 1. 노래 재생
+  2. 도~시 계이름 연주
+  3. 재생/중지
+  4. 볼륨 조절 (DUTY 10%씩 +-)
+  5. 조도에 따라 볼륨 조절 모드
+ 
+## 환경
+- atmel studio: ATmega128A 코딩 및 코드 다운
+- python(vscode) : pyserial로 uart통신하여 위의 5가지 기능 수행

--- a/buzzer+adc+uart/buzzer_gui.py
+++ b/buzzer+adc+uart/buzzer_gui.py
@@ -1,0 +1,87 @@
+from tkinter import *
+import serial
+
+def openSerial(port, baudrate=9600, bytesize=serial.EIGHTBITS, parity=serial.PARITY_ODD, stopbits=serial.STOPBITS_ONE, timeout=1, xonxoff=False, rtscts=False, dsrdtr=False):
+    ser = serial.Serial()
+
+    ser.port = port
+    ser.baudrate = baudrate
+    ser.bytesize = bytesize
+    ser.parity = parity
+    ser.stopbits = stopbits
+    ser.timeout = timeout
+    ser.xonxoff = xonxoff
+    ser.rtscts = rtscts
+    ser.dsrdtr = dsrdtr
+
+    ser.open()
+    return ser
+
+
+def writePort(ser, data):
+    if isinstance(data, str):
+        data = data.encode()
+        print(data)
+    ser.write(data)
+
+# GUI root 열기
+tk = Tk()
+tk.title("시리얼 버튼 테스트")
+
+#  시리얼 포트 열기
+ser = openSerial('COM3')
+
+
+def send_note(note_name):
+    data = f'{note_name}'
+    writePort(ser, data)
+    print(f"전송: {data.strip()}")
+
+songs = ['1', '2', '3']
+
+for i, song in enumerate(songs):
+    btn_song = Button(tk, text=song, width=10, command=lambda n=song: send_note(n))
+    btn_song.grid(row=0, column=i+2, padx=20, pady=10)
+
+notes = ['C', 'D', 'E', 'F', 'G', 'A', 'B']
+for i, note in enumerate(notes):
+    btn = Button(tk, text=note, width=10, command=lambda n=note: send_note(n))
+    btn.grid(row=1, column=i, padx=20, pady=10)
+
+
+playBtn = Button(tk, text = "Play", width=10, command=lambda : send_note('p'))
+playBtn.grid(row=2, column=3, padx=20, pady=10)
+stopBtn = Button(tk, text="Stop", width=10, command=lambda : send_note('s'))
+stopBtn.grid(row=2, column=2, padx=20, pady=10)
+
+volume = 100
+
+# def setVolume(n):
+#     if n == '0':
+#         
+#         if (volume - 10) >= 0:
+#             volume-=10
+#     elif n == '9':
+#         send_note('9')
+#         if (volume + 10) <= 100:
+#             volume += 10
+
+
+
+volumeDownBtn = Button(tk, text= "🔉", width=10, command=lambda: send_note('0'))
+volumeUpBtn = Button(tk, text= "🔊", width=10, command=lambda: send_note('9'))
+#volumeOffBtn = Button(tk, text= "🔇", width=10, command=lambda: send_note('.'))
+volumeDownBtn.grid(row=3, column=3, padx=20, pady=10)
+volumeUpBtn.grid(row=3, column=4, padx=20, pady=10)
+#volumeOffBtn.grid(row=3, column=2, padx=20, pady=10)
+
+#volumeText = Label(tk, text={volume})
+#volumeText.grid(row=3, column=4, padx=20, pady=10)
+
+ADCBtn = Button(tk, text= "volume according to lux", width=40, command=lambda: send_note('8'))
+ADCBtn.grid(row=3, column=8, padx=20, pady=10)
+
+
+tk.mainloop()
+
+ser.close()

--- a/buzzer+adc+uart/define.h
+++ b/buzzer+adc+uart/define.h
@@ -1,0 +1,26 @@
+#ifndef DEFINE_H_
+#define DEFINE_H_
+
+// clock
+#define F_CPU 16000000UL
+#define BAUD 9600
+
+
+//
+#define L_DO 523
+#define L_RE 587
+#define FA_ 740
+#define SOL 784
+#define RA 880
+#define TI 988
+#define DO 1047
+#define DO_ 1109
+#define RE 1175
+#define RE_ 1245
+#define MI 1319
+#define FA 1397
+#define H_SOL 1568
+
+
+
+#endif /* DEFINE_H */

--- a/buzzer+adc+uart/main.c
+++ b/buzzer+adc+uart/main.c
@@ -1,0 +1,30 @@
+#include <avr/io.h>
+#include <avr/interrupt.h>
+
+
+#include "ADC.h"
+#include "uart.h"
+#include "timer1.h"
+#include "External_Interrupt.h";
+#include "task.h"
+ 
+
+
+int main()
+{
+	usart_init();
+	ADC_init();
+	// ExternalInterrupt_init();
+	set_timer1_Fast_PWM(1);
+	task_init();
+
+	DDRB |=(1<<6);
+	DDRA = 0XFF;
+
+	sei(); // xc8 에선 실행 안 됨
+
+	while (1)
+	{
+		
+	}
+}

--- a/buzzer+adc+uart/task.c
+++ b/buzzer+adc+uart/task.c
@@ -1,0 +1,156 @@
+// 1ms 태스크
+#include <avr/io.h>
+#include <avr/interrupt.h>
+
+#include "define.h"
+#include "ADC.h"
+#include "uart.h"
+#include "timer1.h"
+#include "External_Interrupt.h"
+#include "task.h"
+
+unsigned volatile int task_1ms = 0; // 1ms
+unsigned volatile int task_2ms = 0; // 2ms
+// unsigned volatile int task_250ms =0;	// 250ms
+unsigned volatile int task_1s = 0; // 10ms
+
+
+void task_init()
+{
+	TCCR0 |= (1 << WGM01); // CTC 모드
+	TCCR0 |= (1 << CS02);  // 64 분주
+
+	OCR0 = 249; // F_CPU / 64 / 1000 - 1 -> 1ms
+
+	TIMSK |= (1 << OCIE0);
+}
+
+void play_note()
+{ // 250ms task
+	if (play_mode == 1)
+	{
+		if ((song_idx >= 0) && (song_idx < song_len))
+		{
+			pitch = song_pointer[song_idx];
+			set_pitch();
+			set_pwm_duty(volume);
+		}
+		else
+		{
+			play_mode = 0;
+			pre_volume = volume;
+
+			set_pwm_duty(0);
+
+			song_pointer = 0; // 끝나서 리셋
+			song_len = 0;
+			song_idx = 0;
+		}
+	}
+}
+
+void do_every_1ms()	
+{
+	PORTA ^= 0x01; // 오실로스코프 측정용 led 점등 (1ms가 맞는지)
+	
+	// 모드 확인용 led 점등---------------------------------------------
+	if (play_mode)
+		PORTA |= 0x20;
+	else
+		PORTA &= ~0x20;
+
+	if (adc_volume_mode)
+		PORTA |= 0X80;
+	else
+		PORTA &= ~0X80;
+
+	if (volume_onoff_mode)
+		PORTA |= 0x40;
+	else
+		PORTA &= ~0X40;
+	//----------------------------------------------------------------
+	
+	
+	// 1ms 마다 uart receive하기
+	char recv;
+	if (uart_receive(&recv))
+	{
+		change_pitch(recv);
+	}
+}
+
+void do_every_2ms(){
+	if (adc_volume_mode == 1)
+	{
+		uart_send(adc_high);
+		uart_send(adc_low);
+	}
+}
+
+void do_every_5ms()
+{
+	// ------- adc volume 모드 ---------
+
+	if (adc_volume_mode == 1)
+	{
+		unsigned short value = ADC_read();
+
+		// unsigned short duty = (uint32_t)(value * 100) / 1023;
+		uint16_t duty = (uint32_t)value * 100 / 1023;
+
+		set_pwm_duty(duty);
+	} // -------------------------------
+	else
+	{
+		set_pwm_duty(volume);
+	}
+}
+
+void do_every_1s()
+{
+	
+}
+
+void task()
+{
+	
+	do_every_1ms();
+	if (task_1ms % 300 == 0)
+	{
+		if (play_mode == 1)
+		{
+			song_idx++;
+			play_note();
+		}
+	}
+	if (task_1ms % 2 == 0)
+	{
+		do_every_2ms();
+		
+	}
+
+	if (task_1ms % 5 == 0)
+	{
+
+		do_every_5ms();
+	}
+
+	if (task_1ms % 1000 == 0)
+	{ // 1초 TASK
+		task_1s++;
+		do_every_1s();
+	}
+
+	if (task_1ms >= 1000000)
+	{
+		task_1ms = 0;
+		task_1s = 0;
+	}
+}
+
+ISR(TIMER0_COMP_vect)
+{
+	task_1ms++;
+
+	task();
+}

--- a/buzzer+adc+uart/task.h
+++ b/buzzer+adc+uart/task.h
@@ -1,0 +1,8 @@
+#ifndef TASK_H_
+#define TASK_H_
+
+unsigned volatile int count;
+
+void task_init();
+
+#endif

--- a/buzzer+adc+uart/timer1.c
+++ b/buzzer+adc+uart/timer1.c
@@ -1,0 +1,240 @@
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include "define.h"
+#include "timer1.h"
+
+volatile int pitch = DO;
+volatile int top = 0;
+volatile int pre_volume = 100;
+volatile int volume = 100;
+
+volatile int play_mode = 0;			// 재생 중이면 1, 정지 or 노래 끝 0
+volatile int adc_volume_mode = 0;	// adc로 듀티 조절 할 거면 1, 아니면 0
+volatile int volume_onoff_mode = 1; // 1: 소리 켜기, 0: 소리 끄기
+
+int *song_pointer = 0;
+unsigned int song_len = 0;
+volatile int song_idx = 0;
+
+const unsigned int grandpa_song[198] = {
+	SOL, SOL, DO, DO, TI, DO, RE, RE, DO, RE, MI, MI, FA, MI, RA, RA, RE, RE, DO, DO, DO, DO,
+	TI, TI, RA, TI, DO, DO, DO, DO, DO, DO, SOL, SOL, DO, DO, TI, DO, RE, RE, DO, RE, MI, MI,
+	FA, MI, RA, RA, RE, RE, DO, DO, DO, DO, TI, TI, RA, TI, DO, DO, DO, DO, DO, DO, DO, MI,
+	SOL, SOL, MI, RE, DO, DO, TI, DO, RE, DO, TI, RA, SOL, SOL, DO, MI, SOL, SOL, MI, RE, DO,
+	DO, TI, DO, RE, RE, RE, RE, RE, RE, RE, SOL, SOL, DO, DO, DO, DO, RE, RE, RE, RE, MI, MI,
+	FA, MI, RA, RA, RE, RE, DO, DO, DO, DO, TI, TI, RA, SOL, DO, DO, DO, DO, DO, DO, DO, SOL,
+	SOL, DO, DO, TI, DO, RE, RE, DO, RE, MI, MI, FA, MI, RA, RA, RE, RE, DO, DO, DO, DO, TI,
+	TI, RA, TI, DO, DO, DO, DO, DO, DO, SOL, SOL, DO, DO, SOL, SOL, RA, RA, SOL, SOL, MI, SOL,
+	MI, SOL, SOL, DO, DO, SOL, SOL, RA, RA, SOL, SOL, MI, MI, SOL, SOL, MI, MI, SOL, SOL, DO,
+	DO, DO, DO, RE, RE, RE, RE, MI, MI, FA, RA, RA, RE, RE, DO, DO, DO, DO, TI, TI, RA, TI, DO,
+	DO, DO, DO, DO, DO, MI, MI, FA, FA, SOL, SOL, FA, FA, MI, MI, MI, MI, MI, MI};
+const unsigned int candy[72] = {
+	L_RE, SOL, RA, TI, TI, TI, DO, DO, DO, DO, TI, RA, RA, RA, TI, TI, L_RE, SOL, RA, TI, TI, RA, RA, SOL, SOL, TI, TI, TI, DO, TI, DO, TI, RA, SOL, RA, TI, TI, TI, DO, DO, DO, DO, TI, RA, RA, RA, TI, TI, RA, RA, RA, SOL, FA_, SOL, SOL, FA_, SOL, MI, MI, DO, DO, TI, TI, RA, RA, SOL, SOL, FA_, FA_, SOL, SOL, RA, RA, SOL, SOL, SOL, SOL};
+const unsigned int SCHOOL_BELL[28] = {
+	SOL, SOL, RA, RA, SOL, SOL, MI, MI,
+	SOL, SOL, MI, MI, L_RE, L_RE, L_RE, L_RE,
+	SOL, SOL, RA, RA, SOL, SOL, MI, MI,
+	SOL, SOL, L_RE, MI, L_DO, L_DO, L_DO, L_DO};
+
+void set_pwm_duty(uint16_t percent)
+{
+
+	if (percent <= 0)
+	{
+		volume = 0;
+		volume_onoff_mode = 0;
+		TCCR1A &= ~(1 << COM1B1); // OC1B 해제 (PWM X)
+		TIMSK &= ~(1 << OCIE1B);  // 인터럽트도 꺼줌
+
+		PORTB &= ~(1 << 6); // 부저 핀 출력 끄기
+
+		return;
+	}
+
+	if (percent >= 100)
+	{
+		volume = 101;
+		TCCR1A &= ~(1 << COM1B1); // OC1B 해제 (PWM X)
+	}
+	else
+		TCCR1A |= (1 << COM1B1); // OC1B 연결
+
+	TIMSK |= (1 << OCIE1B);
+
+	volume_onoff_mode = 1;
+
+	uint16_t ocr = top / 100 * percent;
+
+	OCR1BH = ocr >> 8;
+	OCR1BL = (uint8_t)ocr;
+
+	// OCR1A = ocr;
+}
+
+void set_pitch()
+{
+	top = (F_CPU / pitch) - 1;
+
+	OCR1AH = top >> 8;
+	OCR1AL = (uint8_t)top;
+}
+
+void set_timer1_CS(int n)
+{
+	switch (n)
+	{
+	case 1:
+		TCCR1B |= (1 << CS10);
+		break;
+	case 8:
+		TCCR1B |= (1 << CS11);
+		break;
+	case 64:
+		TCCR1B |= (1 << CS11) | (1 << CS10);
+		break;
+	case 256:
+		TCCR1B |= (1 << CS12);
+		break;
+	case 1024:
+		TCCR1B |= (1 << CS12) | (1 << CS10);
+		break;
+	}
+}
+
+void set_timer1_Fast_PWM(int n)
+{
+	TCCR1A |= (1 << COM1B1) | (1 << WGM11) | (1<<WGM10); // non-inverting mode
+	TCCR1B |= (1 << WGM12) | (1 << WGM13);	// Fast PWM (wgm3:0 = 1 1 1 1) : TOP = OCR1A
+	set_timer1_CS(n);
+
+	set_pitch();
+
+	TIMSK |= (1 << OCIE1B);
+}
+
+void change_pitch(char c)
+{
+
+	if (c == 'C' || c == 'c')
+	{
+		pitch = DO;
+		
+	}
+	else if (c == 'D' || c == 'd')
+	{
+		pitch = RE;
+	}
+	else if (c == 'E' || c == 'e')
+	{
+		pitch = MI;
+	}
+	else if (c == 'F' || c == 'f')
+	{
+		pitch = FA;
+	}
+	else if (c == 'G' || c == 'g')
+	{
+		pitch = H_SOL;
+	}
+	else if (c == 'A' || c == 'a')
+	{
+		pitch = RA;
+	}
+	else if (c == 'B' || c == 'b')
+	{
+		pitch = TI;
+	}
+	else if (c == '1')
+	{
+
+		song_pointer = grandpa_song; // song pointer가 할아버지 시계 배열 가리킴
+		song_len = sizeof(grandpa_song) / sizeof(int);
+		song_idx = 0;
+
+		play_mode = 1;
+
+		return;
+	}
+	else if (c == '2')
+	{
+
+		song_pointer = candy; // song pointer가 candy 배열 가리킴
+		song_len = sizeof(candy) / sizeof(int);
+		song_idx = 0;
+
+		play_mode = 1;
+
+		return;
+	}
+	else if (c == '3')
+	{
+
+		song_pointer = SCHOOL_BELL; // song pointer가 학교종 배열 가리킴
+		song_len = sizeof(SCHOOL_BELL) / sizeof(int);
+		song_idx = 0;
+
+		play_mode = 1;
+
+		return;
+	}
+	else if (c == '9')
+	{ // volume up
+		if (volume + 10 <= 101)
+		{
+			volume += 10;
+			pre_volume = volume;
+			set_pwm_duty(volume);
+		}
+		return;
+	}
+	else if (c == '0')
+	{ // volume down
+		if (volume - 10 > 1)	// TOP을 101로 해서 10씩 빼면 0%가 되어야 할 때 1%가 되므로 1 미만은 0%로 만든다.
+		{
+			volume -= 10;
+			pre_volume = volume;
+			set_pwm_duty(volume);
+		}
+		else{
+			//volume = 0;
+			//volume_onoff_mode = 0;
+			set_pwm_duty(0);
+		}
+
+		return;
+	}
+
+	else if (c == 's')
+	{ // stop
+		play_mode = 0;
+		if(volume > 0)	pre_volume = volume;	// stop 여러 번 누르면 pre_volume이 0이 되어서 볼륨 갱신이 안 돼서 조건문 추가
+		//set_pwm_duty(0);
+		volume = 0;
+		
+		return;
+	}
+	else if (c == 'p')
+	{ // play
+		play_mode = 1;
+
+		volume = pre_volume; // 재생하던 볼륨 다시 갱신
+		//set_pwm_duty(volume);
+		
+		return;
+	}
+
+	else if (c == '8')
+	{ // adc로 볼륨 조절 시작/끄기
+		adc_volume_mode ^= 1;
+
+		return;
+	}
+	
+	if (play_mode == 0) volume = pre_volume;	// STOP 일 때도 계이름 누르면 바로 재생 되게 볼륨 갱신
+		
+	set_pitch();			// 주파수 변경
+}
+ISR(TIMER1_COMPB_vect)
+{
+	PORTB |=(1<<6); // OC1B(PB6) 핀
+}

--- a/buzzer+adc+uart/timer1.h
+++ b/buzzer+adc+uart/timer1.h
@@ -1,0 +1,27 @@
+#ifndef TIMER1_H_
+#define TIMER1_H_
+
+volatile int pitch;
+volatile int top;
+volatile int pre_volume;
+volatile int volume;
+
+volatile int play_mode;
+volatile int adc_volume_mode;
+volatile int volume_onoff_mode;
+
+int *song_pointer;
+unsigned int song_len;
+volatile int song_idx;
+
+extern const unsigned int grandpa_song[198];
+extern const unsigned int candy[72];
+extern const unsigned int SCHOOL_BELL[28];
+
+void set_pwm_duty(uint16_t percent);
+void set_pitch();
+void set_timer1_CS(int n);
+void set_timer1_Fast_PWM(int n);
+void change_pitch(char c);
+
+#endif /* TIMER1_H_ */

--- a/buzzer+adc+uart/uart.c
+++ b/buzzer+adc+uart/uart.c
@@ -1,0 +1,51 @@
+// uart.c
+
+#include "define.h"
+#include <avr/io.h>
+#include "uart.h"
+
+volatile char receive_buffer = 0;
+
+void usart_init()
+{
+	DDRE = 0X02; // PE 1 출력, PE 0 입력 설정
+
+	UCSR0A = 0X00;
+	UCSR0B = 0b00011000;	// UCSR0B |= (1 << RXEN0) | (1 << TXEN0);					// RX 수신 TX 송신 허용, (인터럽트 수신 하려면 (1<<RXCIE0) 추가)
+	
+	UCSR0C = 0b00100110;	//UCSR0C |= (1 << UPM01) | (1 << UPM00) | (1 << UCSZ01) | (1 << UCSZ00); // 비동기 통신, ODD PARITY, 8bit 데이터
+							//UCSR0C &= ~(1 << USBS0);											   // STOP BIT = 1
+	
+	
+	unsigned int ubrr = (F_CPU / 16 / BAUD) - 1;						   //(16,000,000 / (16 * 9600)) - 1
+	UBRR0H = ubrr >> 8;
+	UBRR0L = (uint8_t)ubrr;
+}
+
+char uart_receive(char *data)
+{
+	if (UCSR0A & (1 << RXC0))
+	{
+		*data = UDR0;
+		return 1;
+	}
+	return 0;	// Polling 형식 uart receive
+}
+
+void uart_send(char data)
+{
+	while (!(UCSR0A & (1 << UDRE0)))
+		; // 송신 대기
+	UDR0 = data;
+}
+
+void uart_flush()
+{
+	unsigned char dummy;
+	while (UCSR0A & (1 << RXC0))
+		dummy = UDR0;
+}
+
+/*ISR(USART0_RX_vect){
+	receive_buffer = UDR0;
+}*/	// 인터럽트 수신 방식

--- a/buzzer+adc+uart/uart.h
+++ b/buzzer+adc+uart/uart.h
@@ -1,0 +1,11 @@
+#ifndef UART_H_
+#define UART_H_
+
+volatile char receive_buffer;
+
+void usart_init();
+char uart_receive(char *data);
+void uart_send(char data);
+void uart_flush();
+
+#endif


### PR DESCRIPTION
# buzzer 프로젝트
## 사용핀
- PA0-7: 동작 여부 확인을 위해 사용
- PF0 : ADC0 채널 사용
- PE0-1 : UART 통신을 위해 사용
- PB4 : TIMER 0: 1ms task용
- PB5 : TIMER1A: TOP=OCR1A FAST PWM 모드 사용
- PB6 : TIEMR1B: 외부 부저 연결 + 듀티 조절을 OCR1B로 하기 위해 사용
# 기능
1. 노래 재생
2. 도~시 계이름 연주
3. 재생/중지
4. 볼륨 조절 (DUTY 10%씩 +-)
5. 조도에 따라 볼륨 조절 모드
## 환경
- atmel studio: ATmega128A 코딩 및 코드 다운
- python(vscode) : pyserial로 uart통신하여 위의 5가지 기능 수행

---
특이사항
- fastPWM : top: OCR1A로 설정하는 모드로 하여 안정적인 TOP 변화로 주파수를 변경, OCR1B로 듀티 변경
- UART 통신으로 GUI <-> ATmega128A 연결